### PR TITLE
Update checkout and artifact actions to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout Repository
       if: ${{ inputs.do-checkout == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: get-date
       run: echo "date=$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
       shell: bash
@@ -77,7 +77,7 @@ runs:
 
     # STORE THE BUILD
     - name: Store the build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.artifact_name }}
         path: ${{ inputs.build-location }}


### PR DESCRIPTION
`actions/checkout@v3` and `actions/upload-artifact@v3` are being deprecated - consider updating!